### PR TITLE
Feature: Manually add modules to the list

### DIFF
--- a/src/locale/de-ch.ftl
+++ b/src/locale/de-ch.ftl
@@ -62,3 +62,9 @@ average-grade = Notendurchschnitt
 no-grades = Keine Noten verfügbar
 
 calculate-grade = Notendurchschnitt berechnen
+
+module-manual-add = Modul manuell hinzufügen
+module-short-name = Modul-Kürzel
+add = Hinzufügen
+cancel = Abbrechen
+year = Jahr

--- a/src/locale/de-ch.ftl
+++ b/src/locale/de-ch.ftl
@@ -52,6 +52,7 @@ header-grade = Note
 header-actions = Aktionen
 
 remove-edit = Zurücksetzen
+remove-module = Modul entfernen
 
 export-csv = Als CSV exportieren
 

--- a/src/locale/en.ftl
+++ b/src/locale/en.ftl
@@ -52,6 +52,7 @@ header-grade = Grade
 header-actions = Actions
 
 remove-edit = Undo edits
+remove-module = Delete module
 
 export-csv = Export as CSV
 

--- a/src/locale/en.ftl
+++ b/src/locale/en.ftl
@@ -62,3 +62,9 @@ average-grade = Average Grade
 no-grades = No grades available
 
 calculate-grade = Calculate Average Grade
+
+module-manual-add = Add a module manually
+module-short-name = Module short name
+add = Add
+cancel = Cancel
+year = Year

--- a/src/module.ts
+++ b/src/module.ts
@@ -396,7 +396,9 @@ export function calculateAverageGrade(modules: Module[]): number | null {
   const passedModulesWithGrades = modules.filter((m) => {
     const isPassed = m.state === ModuleState.Passed;
     const hasGrade =
-      m.grade !== null && !isNaN(Number(m.grade.replace(",", ".")));
+      m.grade !== null &&
+      m.grade !== undefined &&
+      !isNaN(Number(m.grade.replace(",", ".")));
     const hasCredits = m.ects !== null;
     return isPassed && hasGrade && hasCredits;
   });

--- a/src/module.ts
+++ b/src/module.ts
@@ -48,6 +48,14 @@ export function formatSemester(semester: Semester): string {
   return `${semester.part}${String(semester.year % 100).padStart(2, "0")}`;
 }
 
+export function compareSemester(valueA: Semester, valueB: Semester): number {
+  if (valueA.year == valueB.year && valueA.part != valueB.part) {
+    return valueA.part == "HS" ? -1 : 1;
+  }
+
+  return valueB.year - valueA.year;
+}
+
 // Returns the starting semester
 // Assumes the modules array is sorted in reverse time order
 export function startingSemester(modules: Module[]): Semester {

--- a/src/overview/add-module-modal.tsx
+++ b/src/overview/add-module-modal.tsx
@@ -1,0 +1,123 @@
+import { For, createSignal } from "solid-js";
+import { Module, ModuleState } from "../module";
+import { t } from "../i18n";
+import * as storage from "../storage";
+import { ModuleEdit } from "../storage";
+
+export const AddModuleModal = (props: { onClose: () => void }) => {
+  const [shortName, setShortName] = createSignal("");
+  const [ects, setEcts] = createSignal("");
+  const [grade, setGrade] = createSignal("");
+  const [semesterPart, setSemesterPart] = createSignal("HS");
+  const [semesterYear, setSemesterYear] = createSignal(
+    new Date().getFullYear().toString(),
+  );
+  const [state, setState] = createSignal(ModuleState.Passed);
+
+  const states = Object.values(ModuleState);
+  const stateValues = states.slice(0, states.length / 2);
+
+  function handleSubmit(e: Event) {
+    e.preventDefault();
+    const newModule: Partial<Module> = {
+      fullId: "manual-" + Date.now(),
+      shortName: shortName(),
+      ects: parseFloat(ects()),
+      state: state(),
+      semester: {
+        part: semesterPart() as "FS" | "HS",
+        year: parseInt(semesterYear()),
+      },
+    };
+
+    if (grade()) {
+      newModule.grade = grade();
+    }
+
+    const editModule: ModuleEdit = {
+      fullId: newModule.fullId!,
+      edits: newModule,
+    };
+
+    storage.editModule(editModule);
+    props.onClose();
+  }
+
+  return (
+    <div style="position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.5); display: flex; justify-content: center; align-items: center; z-index: 1000">
+      <div style="background: white; padding: 1em; border-radius: 4px; width: 300px">
+        <h3>{t("module-manual-add")}</h3>
+        <form onSubmit={handleSubmit}>
+          <div>
+            <label>{t("module-short-name")}*</label>
+            <input
+              type="text"
+              value={shortName()}
+              onInput={(e) => setShortName(e.currentTarget.value)}
+              required
+            />
+          </div>
+          <div>
+            <label>{t("header-ects")}*</label>
+            <input
+              type="number"
+              value={ects()}
+              onInput={(e) => setEcts(e.currentTarget.value)}
+              required
+            />
+          </div>
+          <div>
+            <label>{t("header-grade")}</label>
+            <input
+              type="number"
+              step="0.1"
+              value={grade()}
+              onInput={(e) => setGrade(e.currentTarget.value)}
+            />
+          </div>
+          <div>
+            <label>{t("header-semester")}*</label>
+            <select
+              value={semesterPart()}
+              onChange={(e) => setSemesterPart(e.currentTarget.value)}
+              required
+            >
+              <option value="HS">HS</option>
+              <option value="FS">FS</option>
+            </select>
+          </div>
+          <div>
+            <label>{t("year")}*</label>
+            <input
+              type="number"
+              value={semesterYear()}
+              onInput={(e) => setSemesterYear(e.currentTarget.value)}
+              required
+            />
+          </div>
+          <div>
+            <label>{t("header-state")}*</label>
+            <select
+              value={state()}
+              onChange={(e) => setState(parseInt(e.currentTarget.value))}
+            >
+              <For each={stateValues}>
+                {(s, i) => (
+                  <option value={i()}>
+                    {t(`module-state-${(s as string).toLowerCase()}`)}
+                  </option>
+                )}
+              </For>
+            </select>
+          </div>
+          <div style="margin-top: 1em; display: flex; justify-content: space-between;">
+            <button type="button" onClick={props.onClose}>
+              {t("cancel")}
+            </button>
+            <button type="submit">{t("add")}</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};

--- a/src/overview/style.css
+++ b/src/overview/style.css
@@ -6,6 +6,10 @@ progress[data-fulfilled="true"] {
   accent-color: green;
 }
 
+.cell-module-manual {
+  font-style: italic;
+}
+
 /* Icons */
 .gg-remove-r {
   box-sizing: border-box;
@@ -57,6 +61,60 @@ progress[data-fulfilled="true"] {
 .gg-info::before {
   height: 2px;
   top: 2px;
+}
+.gg-trash {
+  box-sizing: border-box;
+  position: relative;
+  display: block;
+  transform: scale(var(--ggs, 1));
+  width: 10px;
+  height: 12px;
+  border: 2px solid transparent;
+  box-shadow:
+    0 0 0 2px,
+    inset -2px 0 0,
+    inset 2px 0 0;
+  border-bottom-left-radius: 1px;
+  border-bottom-right-radius: 1px;
+  margin-top: 4px;
+}
+.gg-trash-empty {
+  box-sizing: border-box;
+  position: relative;
+  display: block;
+  transform: scale(var(--ggs, 1));
+  width: 10px;
+  height: 12px;
+  border: 2px solid transparent;
+  box-shadow: 0 0 0 2px;
+  border-bottom-left-radius: 1px;
+  border-bottom-right-radius: 1px;
+  margin-top: 4px;
+}
+.gg-trash-empty::after,
+.gg-trash-empty::before {
+  content: "";
+  display: block;
+  box-sizing: border-box;
+  position: absolute;
+}
+.gg-trash-empty::after {
+  background: currentColor;
+  border-radius: 3px;
+  width: 16px;
+  height: 2px;
+  top: -4px;
+  left: -5px;
+}
+.gg-trash-empty::before {
+  width: 10px;
+  height: 4px;
+  border: 2px solid;
+  border-bottom: transparent;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  top: -7px;
+  left: -2px;
 }
 
 /* Table style */

--- a/src/overview/ui.tsx
+++ b/src/overview/ui.tsx
@@ -505,6 +505,23 @@ const ModulesTableNew = (props: {
       field: "ects",
       headerName: t("header-ects"),
       flex: 0.5,
+      editable: true,
+      valueSetter(params: {
+        data: Module;
+        newValue: number | null | undefined;
+      }): boolean {
+        if (params.newValue == null) {
+          return false;
+        }
+
+        storage.editModule({
+          fullId: params.data.fullId,
+          edits: {
+            ects: params.newValue,
+          },
+        });
+        return true;
+      },
     },
     {
       field: "grade",

--- a/src/overview/ui.tsx
+++ b/src/overview/ui.tsx
@@ -1,4 +1,11 @@
-import { For, Show, createEffect, createMemo, createResource } from "solid-js";
+import {
+  For,
+  Show,
+  createEffect,
+  createMemo,
+  createResource,
+  createSignal,
+} from "solid-js";
 import {
   BACHELOR_CREDITS,
   BACHELOR_MAJORS,
@@ -27,6 +34,8 @@ import "ag-grid-community/styles/ag-grid.css";
 import "ag-grid-community/styles/ag-theme-alpine.css";
 import "./style.css";
 import { t } from "../i18n";
+import { AddModuleModal } from "./add-module-modal";
+import { Portal } from "solid-js/web";
 
 export const App = () => {
   const [loadSettings] = createResource(storage.load);
@@ -362,6 +371,7 @@ const ModulesTableNew = (props: {
   modules: Module[];
 }) => {
   let grid: AgGridSolidRef;
+  const [showManualAddModal, setShowManualAddModal] = createSignal(false);
 
   const defaultColDef = {
     filterParams: {
@@ -535,6 +545,18 @@ const ModulesTableNew = (props: {
       >
         {t("export-csv")}
       </a>
+      <a
+        type="button"
+        onclick={() => setShowManualAddModal(true)}
+        style="margin-left: 1em"
+      >
+        {t("module-manual-add")}
+      </a>
+      <Show when={showManualAddModal()}>
+        <Portal>
+          <AddModuleModal onClose={() => setShowManualAddModal(false)} />
+        </Portal>
+      </Show>
     </div>
   );
 };

--- a/src/overview/ui.tsx
+++ b/src/overview/ui.tsx
@@ -24,6 +24,7 @@ import {
   ModuleType,
   Semester,
   semesterFromDate,
+  compareSemester,
 } from "../module";
 import * as api from "./api";
 import * as storage from "../storage";
@@ -409,19 +410,10 @@ const ModulesTableNew = (props: {
       headerName: t("header-semester"),
       filter: "agTextColumnFilter",
       floatingFilter: true,
-      // valueGetter(params: { data: Module }) {
-      //   return `${params.data.semester.part} ${params.data.semester.year}`;
-      // },
       valueFormatter(params: { value: Semester }) {
         return `${params.value.part} ${params.value.year}`;
       },
-      comparator(valueA: Semester, valueB: Semester) {
-        if (valueA.year == valueB.year && valueA.part != valueB.part) {
-          return valueA.part == "HS" ? -1 : 1;
-        }
-
-        return valueB.year - valueA.year;
-      },
+      comparator: compareSemester,
     },
     {
       field: "state",

--- a/src/overview/ui.tsx
+++ b/src/overview/ui.tsx
@@ -36,6 +36,7 @@ import "./style.css";
 import { t } from "../i18n";
 import { AddModuleModal } from "./add-module-modal";
 import { Portal } from "solid-js/web";
+import { ColDef } from "ag-grid-community";
 
 export const App = () => {
   const [loadSettings] = createResource(storage.load);
@@ -390,13 +391,18 @@ const ModulesTableNew = (props: {
     .slice(0, types.length / 2)
     .map((x) => t(`module-type-${(x as string).toLowerCase()}`));
 
-  const columnDefs = [
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const columnDefs: ColDef<any, any>[] = [
     {
       field: "shortName",
       headerName: t("header-module"),
       filter: "agTextColumnFilter",
       floatingFilter: true,
       flex: 1.5,
+      cellClassRules: {
+        "cell-module-manual": (p) =>
+          storage.getModuleEdit(p.data.fullId)?.edits.fullId != undefined,
+      },
     },
     {
       field: "semester",
@@ -562,14 +568,17 @@ const ModulesTableNew = (props: {
 };
 
 const ActionsCell = (props: { data: Module }) => {
+  const moduleEdit = createMemo(() => storage.getModuleEdit(props.data.fullId));
+  const isManual = createMemo(() => moduleEdit()?.edits.fullId != undefined);
+
   return (
-    <Show when={storage.getModuleEdit(props.data.fullId)}>
+    <Show when={moduleEdit()}>
       <div style="height: 100%; display: flex; align-items: center;">
         <a
-          title={t("remove-edit")}
+          title={isManual() ? t("remove-module") : t("remove-edit")}
           onClick={() => storage.deleteModuleEdit(props.data.fullId)}
         >
-          <i class="gg-remove-r"></i>
+          <i class={isManual() ? "gg-trash-empty" : "gg-remove-r"}></i>
         </a>
       </div>
     </Show>

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,6 +1,7 @@
 import { createSignal } from "solid-js";
 import {
   BachelorType,
+  compareSemester,
   MajorType,
   Module,
   ModuleType,
@@ -117,7 +118,9 @@ export function getUserModules(apiModules: Module[]): Module[] {
     )
     .map((moduleEdit) => moduleEdit.edits as Module);
 
-  return [...editedModules, ...manualModules];
+  return [...editedModules, ...manualModules].sort((a, b) =>
+    compareSemester(a.semester, b.semester),
+  );
 }
 
 export async function updateSettings(settings: Settings) {


### PR DESCRIPTION
I tried the extension out and was missing a crucial feature that I rely on to effectively use it.
Some people have externally accredited modules that don't show up on the registration list, so it shows the wrong values in the summary. Since there is no way (at least that I know of) to get them programatically I implemented a feature to be able to manually add the modules.
I tested it on Chrome 133.0.6943.55.
Here's how it looks like:
<img width="997" alt="Screenshot 2025-02-24 at 17 40 27" src="https://github.com/user-attachments/assets/1caeae01-b299-4290-b6a6-8dc5b1ff71f8" />
<img width="1006" alt="image" src="https://github.com/user-attachments/assets/32f84a63-264a-4516-aa5c-56e78ecc24ed" />
